### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ script: mvn -DskipTests=true clean install
 after_success:
   - mvn clean test jacoco:report
   - mvn coveralls:report -DrepoToken="${RepoToken}"
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.